### PR TITLE
Fixed avatar flickering in third person in some worlds

### DIFF
--- a/ReModCE/Components/ThirdPersonComponent.cs
+++ b/ReModCE/Components/ThirdPersonComponent.cs
@@ -19,6 +19,7 @@ namespace ReModCE.Components
         private Camera _cameraBack;
         private Camera _cameraFront;
         private Camera _referenceCamera;
+        private Camera _photoCamera;
 
         private ThirdPersonMode _cameraSetup;
 
@@ -49,6 +50,7 @@ namespace ReModCE.Components
             _hotkeyToggle = hotkeyMenu.AddToggle("Thirdperson Hotkey", "Enable/Disable thirdperson hotkey", EnableThirdpersonHotkey.SetValue, EnableThirdpersonHotkey);
 
             var cameraObject = GameObject.Find("Camera (eye)");
+            _photoCamera = GameObject.Find("UserCamera")?.transform.Find("PhotoCamera")?.GetComponent<Camera>();
 
             if (cameraObject == null)
             {
@@ -59,7 +61,7 @@ namespace ReModCE.Components
                     return;
                 }
             }
-
+            
             _referenceCamera = cameraObject.GetComponent<Camera>();
             if (_referenceCamera == null)
                 return;
@@ -81,6 +83,9 @@ namespace ReModCE.Components
             camera.enabled = false;
             camera.fieldOfView = fieldOfView;
             camera.nearClipPlane /= 4f;
+
+            if(_photoCamera != null)
+                camera.cullingMask = _photoCamera.cullingMask;
 
             return camera;
         }


### PR DESCRIPTION
Third person cameras cause zfighting with the shadow/mirror clone in some worlds/lighting conditions.

https://user-images.githubusercontent.com/106736458/172016324-c5a1fa0e-8929-48db-a918-bf2db051280a.mp4

This fixes it by copying the VR photo camera's culling mask to the new cameras. 
This also fixes the ui displaying twice in third person.